### PR TITLE
Allow to get original GoogleMap

### DIFF
--- a/android-maps-extensions/src/main/java/com/androidmapsextensions/GoogleMap.java
+++ b/android-maps-extensions/src/main/java/com/androidmapsextensions/GoogleMap.java
@@ -195,6 +195,8 @@ public interface GoogleMap {
 
     void stopAnimation();
 
+    com.google.android.gms.maps.GoogleMap getOriginalMap();
+
     interface CancelableCallback extends com.google.android.gms.maps.GoogleMap.CancelableCallback {
 
         @Override

--- a/android-maps-extensions/src/main/java/com/androidmapsextensions/impl/DelegatingGoogleMap.java
+++ b/android-maps-extensions/src/main/java/com/androidmapsextensions/impl/DelegatingGoogleMap.java
@@ -430,6 +430,11 @@ class DelegatingGoogleMap implements GoogleMap {
     }
 
     @Override
+    public com.google.android.gms.maps.GoogleMap getOriginalMap() {
+        return real.getMap();
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;


### PR DESCRIPTION
- This PR adds `getOriginalMap()` getter to this lib GoogleMap interface, which returns original GoogleMap (`com.google.android.gms.maps.GoogleMap`)
- With help of this new function, you can use this library with other Google Maps libraries which requires original Google map like [android-maps-utils](https://github.com/googlemaps/android-maps-utils)